### PR TITLE
fix(gitignore): ignore .ansible cache directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,6 +40,7 @@ compose/coredns/Corefile
 compose/Corefile
 
 # Host shell / editor / tooling state accidentally surfaced inside this working copy
+.ansible
 .bash_profile
 .bashrc
 .gitconfig

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ compose/coredns/Corefile
 compose/Corefile
 
 # Host shell / editor / tooling state accidentally surfaced inside this working copy
+.ansible
 .bash_profile
 .bashrc
 .gitconfig


### PR DESCRIPTION
A root-owned, empty .ansible/ (collections/modules/roles) directory skeleton can appear in the repo root, from some root-run containerized process's Ansible invocation resolving its collections_paths default against the wrong $HOME. Confirmed this is not the project's own convention: every reference in the codebase (Makefile, scripts/install/ all.sh, .github/workflows/lint-ansible.yml) consistently targets ~/.ansible/collections outside the repo, and .ansible/ has never been tracked in this repository's history. Regardless of the exact trigger, this directory is untracked and root-owned, and being previously unlisted caused 'git stash push -u' to abort mid-cleanup on it (EACCES), silently leaving other unrelated working-tree changes unreset.

# Choose a Pull Request Template

🙏 Thank you for your contribution to [https://Infinito.Nexus](https://Infinito.Nexus).

⚠️ Do not submit this chooser as the final pull request description.

👀 Click `View` to render this chooser and make the buttons visible.
Then select the template that best matches your change:

[![Server](https://img.shields.io/badge/Server-web--*-0A7B83?style=for-the-badge)](?quick_pull=1&template=server.md)
[![Workstation](https://img.shields.io/badge/Workstation-desk--*-2E6F40?style=for-the-badge)](?quick_pull=1&template=workstation.md)
[![System](https://img.shields.io/badge/System-sys%2Fsvc%2Fdev-8B5E3C?style=for-the-badge)](?quick_pull=1&template=system.md)

[![Pipeline](https://img.shields.io/badge/Pipeline-CI%2FCD-7A3E9D?style=for-the-badge)](?quick_pull=1&template=pipeline.md)
[![Agents](https://img.shields.io/badge/Agents-AGENTS%2FCLAUDE%2FGEMINI-9C2F2F?style=for-the-badge)](?quick_pull=1&template=agents.md)
[![Documentation](https://img.shields.io/badge/Documentation-docs-1F5C99?style=for-the-badge)](?quick_pull=1&template=documentation.md)

## Fallback

If the buttons do not work in your GitHub client, append one of these query parameters to the current pull request creation URL:

* `&template=server.md`
* `&template=workstation.md`
* `&template=system.md`
* `&template=pipeline.md`
* `&template=agents.md`
* `&template=documentation.md`

### Contribution Guide

📘 Repository-wide contribution and review expectations:

* [CONTRIBUTING.md](../CONTRIBUTING.md)

### Need Help?

💬 If you need support choosing the right template or preparing your pull request:

* [Support and Contact](../SUPPORT.md)
* Hub: <https://hub.infinito.nexus/>
* Matrix: `#public:infinito.nexus`
